### PR TITLE
Add business authentication routes and models

### DIFF
--- a/backEnd/src/controllers/business.js
+++ b/backEnd/src/controllers/business.js
@@ -1,0 +1,247 @@
+const Joi = require("joi");
+const responseCreator = require("../utils/responseCreator");
+const { sequelize } = require("../database/models");
+const passwordComplexity = require("joi-password-complexity");
+const bcrypt = require("bcrypt");
+const tokenManager = require("../utils/tokenManager");
+const config = require("config");
+
+const signUp = {
+  security: {
+    authenticationLayer: false,
+    authorizationLayer: false,
+    validationLayer: true,
+  },
+
+  validationSchema: {
+    body: {
+      name: Joi.string().required().label("Business name"),
+      email: Joi.string().email({ tlds: true }).required().label("Email address"),
+      password: passwordComplexity({
+        min: 8,
+        max: 30,
+        lowerCase: 1,
+        upperCase: 1,
+        numeric: 1,
+        symbol: 1,
+        requirementCount: 4,
+      })
+        .required()
+        .label("Password"),
+      logoURL: Joi.string().allow("").optional().uri().label("Logo URL"),
+      phoneNumber: Joi.string()
+        .allow("")
+        .optional()
+        .pattern(/^[+0-9]+$/, "phone number (Characters allowed: 0-9, +)")
+        .label("Phone number"),
+      address: Joi.string().allow("").optional().label("Address"),
+      websiteURL: Joi.string().allow("").optional().uri().label("Website URL"),
+    },
+  },
+
+  async handler(req, res) {
+    try {
+      const business = await sequelize.transaction(async (t) => {
+        const businessAccountExistance = await sequelize.models.BusinessAccount.findOne(
+          {
+            where: {
+              email: req.body.email,
+            },
+          }
+        );
+
+        if (businessAccountExistance) {
+          if (businessAccountExistance.thirdParty)
+            throw new Error(
+              "You are already registered using the google authorization service"
+            );
+          throw new Error("Email address is already registered");
+        }
+
+        const businessData = { ...req.body };
+        delete businessData["email"];
+        delete businessData["password"];
+
+        const encryptedPassword = await bcrypt.hash(req.body.password, 10);
+
+        const business = await sequelize.models.Business.create(businessData);
+        await sequelize.models.BusinessAccount.create({
+          businessID: business.businessID,
+          email: req.body.email,
+          password: encryptedPassword,
+        });
+
+        delete business.dataValues.createdAt;
+        delete business.dataValues.updatedAt;
+        business.dataValues.email = req.body.email;
+
+        return business;
+      });
+
+      res.cookie(
+        "accessToken",
+        tokenManager.generateToken(
+          { businessID: business.businessID },
+          config.get("ACCESS_TOKEN_SECRET"),
+          `${1000 * 60 * 60 * 24 * config.get("ACCESS_TOKEN_TIME")}`
+        ),
+        {
+          sameSite: "none",
+          path: "/",
+          expires: new Date(
+            new Date().getTime() +
+              1000 * 60 * 60 * 24 * config.get("ACCESS_TOKEN_TIME")
+          ),
+          httpOnly: true,
+          secure: true,
+          signed: true,
+        }
+      );
+
+      res
+        .status(200)
+        .send(
+          responseCreator(
+            "success",
+            "Successfully registered the new business",
+            business
+          )
+        );
+    } catch (e) {
+      const errorMsg = e.message;
+
+      switch (errorMsg) {
+        case "Email address is already registered":
+          res
+            .status(400)
+            .send(
+              responseCreator("error", "Email address is already registered")
+            );
+          break;
+        case "You are already registered using the google authorization service":
+          res
+            .status(400)
+            .send(
+              responseCreator(
+                "error",
+                "You are already registered using the google authorization service"
+              )
+            );
+          break;
+        default:
+          res
+            .status(400)
+            .send(responseCreator("error", "Request can't be proceed"));
+      }
+    }
+  },
+};
+
+const signIn = {
+  security: {
+    authenticationLayer: false,
+    authorizationLayer: false,
+    validationLayer: true,
+  },
+
+  validationSchema: {
+    body: {
+      email: Joi.string().email({ tlds: true }).required().label("Email address"),
+      password: Joi.string().required().label("Password"),
+    },
+  },
+
+  async handler(req, res) {
+    try {
+      const business = await sequelize.transaction(async (t) => {
+        const businessAccount = await sequelize.models.BusinessAccount.findOne({
+          where: {
+            email: req.body.email,
+          },
+        });
+
+        if (!businessAccount) throw new Error("Wrong Password or Email");
+
+        if (businessAccount.thirdParty)
+          throw new Error(
+            "You registered using the google authorization service, Please use the google sign in to access the account"
+          );
+
+        const isPasswordCorrect = await bcrypt.compare(
+          req.body.password,
+          businessAccount.password
+        );
+
+        if (!isPasswordCorrect) throw new Error("Wrong Password or Email");
+
+        const business = await sequelize.models.Business.findOne({
+          attributes: ["businessID", "name"],
+          where: {
+            businessID: businessAccount.businessID,
+          },
+        });
+
+        business.dataValues.email = businessAccount.email;
+
+        return business;
+      });
+
+      res.cookie(
+        "accessToken",
+        tokenManager.generateToken(
+          { businessID: business.businessID },
+          config.get("ACCESS_TOKEN_SECRET"),
+          `${1000 * 60 * 60 * 24 * config.get("ACCESS_TOKEN_TIME")}`
+        ),
+        {
+          sameSite: "none",
+          path: "/",
+          expires: new Date(
+            new Date().getTime() +
+              1000 * 60 * 60 * 24 * config.get("ACCESS_TOKEN_TIME")
+          ),
+          httpOnly: true,
+          secure: true,
+          signed: true,
+        }
+      );
+
+      res
+        .status(200)
+        .send(
+          responseCreator(
+            "success",
+            "Business is successfully authenticated",
+            business
+          )
+        );
+    } catch (e) {
+      const errorMsg = e.message;
+      console.log(errorMsg);
+
+      switch (errorMsg) {
+        case "Wrong Password or Email":
+          res
+            .status(401)
+            .send(responseCreator("error", "Email or password is incorrect"));
+          break;
+        case "You registered using the google authorization service, Please use the google sign in to access the account":
+          res
+            .status(400)
+            .send(
+              responseCreator(
+                "error",
+                "You registered using the google authorization service, Please use the google sign in to access the account"
+              )
+            );
+          break;
+        default:
+          res
+            .status(400)
+            .send(responseCreator("error", "Request can't be proceed"));
+      }
+    }
+  },
+};
+
+module.exports = { signUp, signIn };

--- a/backEnd/src/database/migrations/20250101000000-create-business.js
+++ b/backEnd/src/database/migrations/20250101000000-create-business.js
@@ -1,0 +1,40 @@
+"use strict";
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("Businesses", {
+      businessID: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      logoURL: {
+        type: Sequelize.STRING,
+      },
+      phoneNumber: {
+        type: Sequelize.STRING,
+      },
+      address: {
+        type: Sequelize.STRING,
+      },
+      websiteURL: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("Businesses");
+  },
+};

--- a/backEnd/src/database/migrations/20250101000001-create-business-account.js
+++ b/backEnd/src/database/migrations/20250101000001-create-business-account.js
@@ -1,0 +1,51 @@
+"use strict";
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("BusinessAccounts", {
+      businessID: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        references: {
+          model: "Businesses",
+          key: "businessID",
+          as: "businessID",
+        },
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: Sequelize.STRING,
+      },
+      thirdParty: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      provider: {
+        type: Sequelize.STRING,
+      },
+      providerUserID: {
+        type: Sequelize.STRING,
+      },
+      status: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: "active",
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("BusinessAccounts");
+  },
+};

--- a/backEnd/src/database/models/business.js
+++ b/backEnd/src/database/models/business.js
@@ -1,0 +1,28 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+  class Business extends Model {
+    static associate(models) {
+      // define association here
+    }
+  }
+  Business.init(
+    {
+      businessID: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: { type: DataTypes.STRING, allowNull: false },
+      logoURL: { type: DataTypes.STRING },
+      phoneNumber: { type: DataTypes.STRING },
+      address: { type: DataTypes.STRING },
+      websiteURL: { type: DataTypes.STRING },
+    },
+    {
+      sequelize,
+      modelName: "Business",
+    }
+  );
+  return Business;
+};

--- a/backEnd/src/database/models/businessaccount.js
+++ b/backEnd/src/database/models/businessaccount.js
@@ -1,0 +1,39 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+  class BusinessAccount extends Model {
+    static associate(models) {
+      models.Business.hasOne(models.BusinessAccount, {
+        foreignKey: "businessID",
+      });
+      models.BusinessAccount.belongsTo(models.Business, {
+        foreignKey: "businessID",
+      });
+    }
+  }
+  BusinessAccount.init(
+    {
+      businessID: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      email: { type: DataTypes.STRING, allowNull: false, unique: true },
+      password: DataTypes.STRING,
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "active",
+      },
+      thirdParty: { type: DataTypes.BOOLEAN, defaultValue: false },
+      provider: DataTypes.STRING,
+      providerUserID: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: "BusinessAccount",
+    }
+  );
+  return BusinessAccount;
+};

--- a/backEnd/src/index.js
+++ b/backEnd/src/index.js
@@ -19,6 +19,7 @@ const exampleRouter = require("./routes/exampleRouter");
 const authRouter = require("./routes/authRouter");
 const connectionRouter = require('./routes/connectionRouter');
 const thirdPartyAuthRouter = require("./routes/thirdPartyAuthRouter");
+const businessRouter = require("./routes/businessRouter");
 
 app.get("/", (req, res) => {
   res.status(200).send("Server is ok!");
@@ -28,6 +29,7 @@ app.use("/api/example", exampleRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/connection", connectionRouter);
 app.use("/api/auth/third-party", thirdPartyAuthRouter);
+app.use("/api/business", businessRouter);
 
 const port = process.env.PORT || 8000;
 

--- a/backEnd/src/routes/businessRouter.js
+++ b/backEnd/src/routes/businessRouter.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const handleRequest = require("../utils/requestHandler");
+
+router.post("/signup", handleRequest("business", "signUp"));
+router.post("/signin", handleRequest("business", "signIn"));
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Business and BusinessAccount Sequelize models
- create migrations for Businesses and BusinessAccounts tables
- implement business signup/signin controllers and routes

## Testing
- `cd backEnd && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1fafad788322ac29135e486cac6c