### PR TITLE
Add business logo upload support

### DIFF
--- a/backEnd/src/controllers/business.js
+++ b/backEnd/src/controllers/business.js
@@ -244,4 +244,26 @@ const signIn = {
   },
 };
 
-module.exports = { signUp, signIn };
+const updateLogo = {
+  security: {
+    authenticationLayer: true,
+    authorizationLayer: false,
+    validationLayer: false,
+  },
+
+  async handler(req, res, next) {
+    try {
+      await sequelize.models.Business.update(
+        { logoURL: `uploads/business/${req.user.businessID}` },
+        { where: { businessID: req.user.businessID } }
+      );
+      next();
+    } catch (e) {
+      res
+        .status(400)
+        .send(responseCreator("error", "Request can't be proceed"));
+    }
+  },
+};
+
+module.exports = { signUp, signIn, updateLogo };

--- a/backEnd/src/routes/businessRouter.js
+++ b/backEnd/src/routes/businessRouter.js
@@ -1,8 +1,14 @@
 const express = require("express");
 const router = express.Router();
 const handleRequest = require("../utils/requestHandler");
+const handleImageUpload = require("../utils/imageUploadHandler");
 
 router.post("/signup", handleRequest("business", "signUp"));
 router.post("/signin", handleRequest("business", "signIn"));
+router.patch(
+  "/logo",
+  handleRequest("business", "updateLogo"),
+  handleImageUpload("logo", "businessID")
+);
 
 module.exports = router;

--- a/backEnd/src/utils/imageUploadHandler.js
+++ b/backEnd/src/utils/imageUploadHandler.js
@@ -1,10 +1,12 @@
 const multer = require('multer');
 
-function handleImageUpload(imageName) {
+// imageName: field name, idField: 'userID' (default) or 'businessID'
+function handleImageUpload(imageName, idField = 'userID') {
     const storage = multer.diskStorage({
-        destination: 'uploads/',
+        destination: idField === 'businessID' ? 'uploads/business/' : 'uploads/',
         filename: function (req, file, callBack) {
-            callBack(null, req.user.userID);
+            const name = idField === 'businessID' ? req.user.businessID : req.user.userID;
+            callBack(null, name);
         }
     });
 

--- a/frontEnd/src/components/business/BusinessLogoUploader.jsx
+++ b/frontEnd/src/components/business/BusinessLogoUploader.jsx
@@ -1,0 +1,51 @@
+import React, { useContext, useState } from 'react';
+import { Modal, Box } from '@material-ui/core';
+import MyAvatarUploader from '../common/MyAvatarUploader';
+import api from '../../helpers/api';
+import { getImageBlob } from '../../helpers/fileUpload';
+import { AlertContext } from '../../Routes';
+
+const BusinessLogoUploader = ({ open, onClose }) => {
+  const { setAlertMsg, setAlertType, setAlertOpen } = useContext(AlertContext);
+  const [uploading, setUploading] = useState(false);
+
+  const handleUpload = async (file) => {
+    const blobResponse = await getImageBlob(file);
+    if (blobResponse.success) {
+      const formData = new FormData();
+      formData.append('logo', blobResponse.data);
+      setUploading(true);
+      const response = await api.business.uploadLogo(formData);
+      if (response.type === 'success') {
+        setAlertMsg(response.msg);
+        setAlertType('success');
+        setAlertOpen(true);
+        onClose();
+      } else {
+        setAlertMsg(response.msg);
+        setAlertType('error');
+        setAlertOpen(true);
+      }
+      setUploading(false);
+    } else {
+      setAlertMsg('Error preparing image upload');
+      setAlertType('error');
+      setAlertOpen(true);
+    }
+  };
+
+  return (
+    <Modal open={open}>
+      <Box style={{ position: 'absolute', top: '20%', left: '40%' }}>
+        <MyAvatarUploader
+          onClose={onClose}
+          onUpload={(file) => handleUpload(file)}
+          updating={uploading}
+        />
+      </Box>
+    </Modal>
+  );
+};
+
+export default BusinessLogoUploader;
+

--- a/frontEnd/src/helpers/api.js
+++ b/frontEnd/src/helpers/api.js
@@ -89,6 +89,12 @@ const api = {
         )
       ),
   },
+  business: {
+    uploadLogo: (data) =>
+      ajaxHandler(
+        axios.patch("/api/business/logo", data, { withCredentials: true })
+      ),
+  },
 };
 
 const urls = {


### PR DESCRIPTION
## Summary
- extend image upload utility to handle business logos
- add `/api/business/logo` route and controller to save logo URL
- add frontend API helper and business logo uploader component

## Testing
- `npm test` (backend)
- `npm test -- --watchAll=false` (frontend) *(fails: react-scripts not found; `npm install` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ae23f7248c83229aee424cc4a8b7a8