### PR TITLE
Add business auth screens and wallet management

### DIFF
--- a/frontEnd/src/Routes.js
+++ b/frontEnd/src/Routes.js
@@ -3,6 +3,9 @@ import { Routes } from "react-router-dom";
 import RouteWrapper from "./components/common/RouteWrapper";
 import Login from "./screens/login";
 import Register from "./screens/register";
+import BusinessLogin from "./screens/businessLogin";
+import BusinessRegister from "./screens/businessRegister";
+import Wallet from "./screens/wallet";
 import Cards from "./screens/cards";
 import Home from "./screens/home";
 import Account from "./screens/account";
@@ -37,8 +40,11 @@ const AppRouter = () => {
         <Routes>
           <RouteWrapper path="/signin" component={Login} />
           <RouteWrapper path="/signup" component={Register} />
+          <RouteWrapper path="/business/signin" component={BusinessLogin} />
+          <RouteWrapper path="/business/signup" component={BusinessRegister} />
           <RouteWrapper path="/google/verify/:token" component={Verify} />
           <RouteWrapper protect={true} path="/cards" component={Cards} />
+          <RouteWrapper protect={true} path="/wallet" component={Wallet} />
           <RouteWrapper
             protect={true}
             path="/editProfile"

--- a/frontEnd/src/components/wallet/WalletManager.jsx
+++ b/frontEnd/src/components/wallet/WalletManager.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState, useContext } from "react";
+import {
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  TextField,
+} from "@material-ui/core";
+import DeleteIcon from "@material-ui/icons/Delete";
+import LocalButton from "../common/LocalButton";
+import api from "../../helpers/api";
+import { AlertContext } from "../../Routes";
+
+const WalletManager = () => {
+  const [cards, setCards] = useState([]);
+  const [newCard, setNewCard] = useState("");
+  const { setAlertMsg, setAlertType, setAlertOpen } = useContext(AlertContext);
+
+  const loadCards = () => {
+    api.wallet.getCards().then((res) => {
+      if (res.type === "success") {
+        setCards(res.data);
+      } else {
+        setAlertMsg(res.msg);
+        setAlertType("error");
+        setAlertOpen(true);
+      }
+    });
+  };
+
+  useEffect(() => {
+    loadCards();
+  }, []);
+
+  const handleAdd = () => {
+    if (!newCard) return;
+    api.wallet.addCard({ number: newCard }).then((res) => {
+      if (res.type === "success") {
+        setAlertMsg(res.msg);
+        setAlertType("success");
+        setAlertOpen(true);
+        setNewCard("");
+        loadCards();
+      } else {
+        setAlertMsg(res.msg);
+        setAlertType("error");
+        setAlertOpen(true);
+      }
+    });
+  };
+
+  const handleRemove = (id) => {
+    api.wallet.removeCard(id).then((res) => {
+      if (res.type === "success") {
+        setAlertMsg(res.msg);
+        setAlertType("success");
+        setAlertOpen(true);
+        loadCards();
+      } else {
+        setAlertMsg(res.msg);
+        setAlertType("error");
+        setAlertOpen(true);
+      }
+    });
+  };
+
+  return (
+    <div>
+      <List>
+        {cards.map((card) => (
+          <ListItem key={card.id} divider>
+            <ListItemText primary={card.number} />
+            <IconButton edge="end" onClick={() => handleRemove(card.id)}>
+              <DeleteIcon />
+            </IconButton>
+          </ListItem>
+        ))}
+      </List>
+      <Grid container spacing={1} alignItems="center">
+        <Grid item xs={8}>
+          <TextField
+            label="Card Number"
+            variant="outlined"
+            fullWidth
+            value={newCard}
+            onChange={(e) => setNewCard(e.target.value)}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <LocalButton
+            variant="contained"
+            color="primary"
+            onClick={handleAdd}
+          >
+            Add
+          </LocalButton>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default WalletManager;

--- a/frontEnd/src/helpers/api.js
+++ b/frontEnd/src/helpers/api.js
@@ -90,9 +90,35 @@ const api = {
       ),
   },
   business: {
+    register: (data) =>
+      ajaxHandler(
+        axios.post("/api/business/sign-up", data, { withCredentials: true })
+      ),
+    login: (data) =>
+      ajaxHandler(
+        axios.post("/api/business/sign-in", data, { withCredentials: true })
+      ),
     uploadLogo: (data) =>
       ajaxHandler(
         axios.patch("/api/business/logo", data, { withCredentials: true })
+      ),
+  },
+  wallet: {
+    getCards: () =>
+      ajaxHandler(
+        axios.get("/api/wallet/cards", { withCredentials: true })
+      ),
+    addCard: (data) =>
+      ajaxHandler(
+        axios.post("/api/wallet/cards", data, { withCredentials: true })
+      ),
+    updateCard: (id, data) =>
+      ajaxHandler(
+        axios.put(`/api/wallet/cards/${id}`, data, { withCredentials: true })
+      ),
+    removeCard: (id) =>
+      ajaxHandler(
+        axios.delete(`/api/wallet/cards/${id}`, { withCredentials: true })
       ),
   },
 };

--- a/frontEnd/src/screens/businessLogin/BusinessLoginBox.jsx
+++ b/frontEnd/src/screens/businessLogin/BusinessLoginBox.jsx
@@ -1,0 +1,107 @@
+import React, { useContext, useState } from "react";
+import { Grid, makeStyles } from "@material-ui/core";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import MyTextField from "../../components/common/MyTextField";
+import LocalButton from "../../components/common/LocalButton";
+import api from "../../helpers/api";
+import { AlertContext } from "../../Routes";
+import { useNavigate } from "react-router-dom";
+import { login } from "../../auth";
+
+const useStyles = makeStyles({
+  box: {
+    width: "100%",
+    padding: "3rem",
+    borderRadius: 20,
+    boxShadow: "0 0 10px grey",
+  },
+  title: {
+    fontSize: "2rem",
+    fontWeight: "bold",
+  },
+  button: {
+    width: "100%",
+    marginTop: "1rem",
+    marginBottom: "0.5rem",
+  },
+});
+
+const validationSchema = Yup.object().shape({
+  email: Yup.string()
+    .email("Email should be a valid email")
+    .required("This field is required"),
+  password: Yup.string().required("This field is required"),
+});
+
+const BusinessLoginBox = () => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const { setAlertMsg, setAlertType, setAlertOpen } = useContext(AlertContext);
+  const [loading, setLoading] = useState(false);
+
+  const formik = useFormik({
+    initialValues: { email: "", password: "" },
+    validationSchema: validationSchema,
+    onSubmit: (values) => {
+      setLoading(true);
+      api.business.login(values).then((res) => {
+        if (res.type === "success") {
+          setAlertMsg(res.msg);
+          setAlertType("success");
+          setAlertOpen(true);
+          login(res.data);
+          navigate("/wallet");
+        } else {
+          setAlertMsg(res.msg);
+          setAlertType("error");
+          setAlertOpen(true);
+        }
+        setLoading(false);
+      });
+    },
+  });
+
+  return (
+    <div className={classes.box}>
+      <div className={classes.title}>Business Sign in</div>
+      <Grid container justifyContent="center">
+        <Grid item md={8} xs={12}>
+          <form onSubmit={formik.handleSubmit}>
+            <MyTextField
+              id="email"
+              name="email"
+              label="Email"
+              type="email"
+              value={formik.values.email}
+              helperText={formik.touched.email && formik.errors.email}
+              onChange={formik.handleChange}
+              error={formik.touched.email && Boolean(formik.errors.email)}
+            />
+            <MyTextField
+              id="password"
+              name="password"
+              label="Password"
+              type="password"
+              value={formik.values.password}
+              helperText={formik.touched.password && formik.errors.password}
+              onChange={formik.handleChange}
+              error={formik.touched.password && Boolean(formik.errors.password)}
+            />
+            <LocalButton
+              type="submit"
+              className={classes.button}
+              variant="contained"
+              color="primary"
+              loading={loading}
+            >
+              Sign in
+            </LocalButton>
+          </form>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default BusinessLoginBox;

--- a/frontEnd/src/screens/businessLogin/index.jsx
+++ b/frontEnd/src/screens/businessLogin/index.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Grid } from "@material-ui/core";
+import BusinessLoginBox from "./BusinessLoginBox";
+
+const BusinessLogin = () => {
+  return (
+    <Grid container alignItems="center" justifyContent="center" style={{ minHeight: "100vh" }}>
+      <Grid container item justifyContent="center" xs={12} md={5}>
+        <BusinessLoginBox />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default BusinessLogin;

--- a/frontEnd/src/screens/businessRegister/BusinessRegisterBox.jsx
+++ b/frontEnd/src/screens/businessRegister/BusinessRegisterBox.jsx
@@ -1,0 +1,139 @@
+import React, { useContext, useState } from "react";
+import { Grid, makeStyles } from "@material-ui/core";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import MyTextField from "../../components/common/MyTextField";
+import LocalButton from "../../components/common/LocalButton";
+import api from "../../helpers/api";
+import { AlertContext } from "../../Routes";
+import { useNavigate } from "react-router-dom";
+
+const useStyles = makeStyles({
+  box: {
+    width: "100%",
+    padding: "3rem",
+    borderRadius: 20,
+    boxShadow: "0 0 10px grey",
+  },
+  title: {
+    fontSize: "2rem",
+    fontWeight: "bold",
+  },
+  button: {
+    width: "100%",
+    marginTop: "1rem",
+    marginBottom: "0.5rem",
+  },
+});
+
+const validationSchema = Yup.object().shape({
+  businessName: Yup.string().required("This field is required"),
+  email: Yup.string()
+    .email("Email should be a valid email")
+    .required("This field is required"),
+  password: Yup.string().required("This field is required"),
+  confirmPassword: Yup.string()
+    .oneOf([Yup.ref("password")], "Password must be the same")
+    .required("This field is required"),
+});
+
+const BusinessRegisterBox = () => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const { setAlertMsg, setAlertType, setAlertOpen } = useContext(AlertContext);
+  const [loading, setLoading] = useState(false);
+
+  const formik = useFormik({
+    initialValues: {
+      businessName: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+    },
+    validationSchema: validationSchema,
+    onSubmit: (values) => {
+      setLoading(true);
+      const data = { ...values };
+      delete data["confirmPassword"];
+      api.business.register(data).then((res) => {
+        if (res.type === "success") {
+          setAlertMsg(res.msg);
+          setAlertType("success");
+          setAlertOpen(true);
+          navigate("/business/signin");
+        } else {
+          setAlertMsg(res.msg);
+          setAlertType("error");
+          setAlertOpen(true);
+        }
+        setLoading(false);
+      });
+    },
+  });
+
+  return (
+    <div className={classes.box}>
+      <div className={classes.title}>Business Sign up</div>
+      <Grid container justifyContent="center">
+        <Grid item md={8} xs={12}>
+          <form onSubmit={formik.handleSubmit}>
+            <MyTextField
+              id="businessName"
+              name="businessName"
+              label="Business Name"
+              type="text"
+              value={formik.values.businessName}
+              helperText={formik.touched.businessName && formik.errors.businessName}
+              onChange={formik.handleChange}
+              error={formik.touched.businessName && Boolean(formik.errors.businessName)}
+            />
+            <MyTextField
+              id="email"
+              name="email"
+              label="Email"
+              type="email"
+              value={formik.values.email}
+              helperText={formik.touched.email && formik.errors.email}
+              onChange={formik.handleChange}
+              error={formik.touched.email && Boolean(formik.errors.email)}
+            />
+            <MyTextField
+              id="password"
+              name="password"
+              label="Password"
+              type="password"
+              value={formik.values.password}
+              helperText={formik.touched.password && formik.errors.password}
+              onChange={formik.handleChange}
+              error={formik.touched.password && Boolean(formik.errors.password)}
+            />
+            <MyTextField
+              id="confirmPassword"
+              name="confirmPassword"
+              label="Confirm Password"
+              type="password"
+              value={formik.values.confirmPassword}
+              helperText={formik.touched.confirmPassword && formik.errors.confirmPassword}
+              onChange={formik.handleChange}
+              error={
+                formik.touched.confirmPassword &&
+                Boolean(formik.errors.confirmPassword)
+              }
+            />
+            <LocalButton
+              type="submit"
+              className={classes.button}
+              variant="contained"
+              color="primary"
+              loading={loading}
+            >
+              Sign up
+            </LocalButton>
+          </form>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default BusinessRegisterBox;

--- a/frontEnd/src/screens/businessRegister/index.jsx
+++ b/frontEnd/src/screens/businessRegister/index.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Grid } from "@material-ui/core";
+import BusinessRegisterBox from "./BusinessRegisterBox";
+
+const BusinessRegister = () => {
+  return (
+    <Grid container alignItems="center" justifyContent="center" style={{ minHeight: "100vh" }}>
+      <Grid container item justifyContent="center" xs={12} md={5}>
+        <BusinessRegisterBox />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default BusinessRegister;

--- a/frontEnd/src/screens/wallet/index.jsx
+++ b/frontEnd/src/screens/wallet/index.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Grid } from "@material-ui/core";
+import WalletManager from "../../components/wallet/WalletManager";
+
+const Wallet = () => {
+  return (
+    <Grid container justifyContent="center" style={{ paddingTop: "2rem" }}>
+      <Grid item xs={12} md={6}>
+        <WalletManager />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Wallet;


### PR DESCRIPTION
## Summary
- add API helpers for business auth and wallet CRUD
- add business register/login and wallet routes
- create business auth screens and wallet management component

## Testing
- `npm install 2>&1 | tail -n 20` *(fails: 403 Forbidden for packages)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21b91868c8322b88dc7f158006b6f